### PR TITLE
update: adding k and j as Up and Down keybinding alternatives

### DIFF
--- a/autoload/bufselect.vim
+++ b/autoload/bufselect.vim
@@ -100,8 +100,8 @@ func s:filterNames(id, key) abort
         \ || a:key == "<C-End>"
     call win_execute(s:popup_winid, 'normal! ' .. a:key)
     let key_handled = 1
-  elseif a:key == "\<Up>"
-        \ || a:key == "\<Down>"
+  elseif a:key == "\<Up>" || a:key == "\k"
+        \ || a:key == "\<Down>" || a:key == "\j"
     " Use native Vim handling of these keys
     let key_handled = 0
   elseif a:key =~ '\f' || a:key == "\<Space>"


### PR DESCRIPTION
Hello,

Thank you for creating this plugin.

I'd like to add `k` and `j` as `Up` and `Down` keybinding alternatives, it's something I imagine other people are probably also used to more than using arrow keys.

Let me know what you think.

Regards,
Ivan